### PR TITLE
Notify channel when code pipeline requires manual approval

### DIFF
--- a/__tests__/lib/Discord.test.ts
+++ b/__tests__/lib/Discord.test.ts
@@ -5,6 +5,7 @@ import {
   AlarmNotification,
   PipelineCodeBuildFailure,
   PipelineCodeDeployFailure,
+  ManualApprovalAttributes,
 } from "../../src/types/common";
 
 const DISCORD_WEBHOOK = process.env.DISCORD_WEBHOOK || "";
@@ -58,6 +59,23 @@ test("create-build-failed-message", async () => {
   expect(message.fields[0].name).toBe("Commit: 123456");
   expect(message.fields[1].name).toBe("View Commit:");
   expect(message.fields[2].name).toBe("View Build Log:");
+});
+
+test("create-manual-approval-required-message", async () => {
+  const approvalAttributes: ManualApprovalAttributes = {
+    link: "http://www.github.com",
+    comment: "Retighten the spiggot on the warp-drive"
+  };
+
+  const discord = new Discord();
+  const message = discord.createManualApprovalMessage(
+    "Unit-Test",
+    approvalAttributes
+  );
+
+  expect(message.fields[0].name).toBe("Review Link:");
+  expect(message.fields[1].name).toBe("Comments:");
+  expect(message.fields.length).toBe(2);
 });
 
 test("create-deploy-failed-message", async () => {

--- a/__tests__/lib/TestSamples.ts
+++ b/__tests__/lib/TestSamples.ts
@@ -230,3 +230,99 @@ export const AWS_CODE_DEPLOY_INFO = {
     computePlatform: "Server",
   },
 };
+
+export const AWS_MANUAL_APPROVAL_REQUEST_INFO = {
+  account: "483376129420",
+  detailType: "CodePipeline Action Execution State Change",
+  region: "ap-southeast-2",
+  source: "aws.codepipeline",
+  time: "2022-04-13T00:02:16Z",
+  notificationRuleArn: "arn:aws:codestar-notifications:ap-southeast-2:483376129420:notificationrule/06486c59533a1ace24d910539fc74bd351ff13e4",
+  detail: {
+    pipeline: "lena-test-pipeline",
+    'execution-id': "31c2dcbd-2a1d-42b0-9f37-5bf8cb693b28",
+    stage: "ManualApproval",
+    action: "Approval",
+    state: "STARTED",
+    region: "ap-southeast-2",
+    type: {
+      owner: "AWS",
+      provider: "Manual",
+      category: "Approval",
+      version: "1"
+    },
+    version: 2
+  },
+  resources: [
+    "arn:aws:codepipeline:ap-southeast-2:483376129420:lena-test-pipeline"
+  ],
+  additionalAttributes: {
+    externalEntityLink: "",
+    customData: ""
+  }
+}
+
+export const AWS_MANUAL_REQUEST_APPROVED = {
+  account: "483376129420",
+  detailType: "CodePipeline Action Execution State Change",
+  region: "ap-southeast-2",
+  source: "aws.codepipeline",
+  time: "2022-04-13T00:05:40Z",
+  notificationRuleArn: "arn:aws:codestar-notifications:ap-southeast-2:483376129420:notificationrule/06486c59533a1ace24d910539fc74bd351ff13e4",
+  detail: {
+    pipeline: "lena-test-pipeline",
+    'execution-id': "31c2dcbd-2a1d-42b0-9f37-5bf8cb693b28",
+    stage: "ManualApproval",
+    'execution-result': {
+      'external-execution-summary': "Approved by arn:aws:sts::483376129420:assumed-role/ax-devops-developer-tier-1/lena",
+      'external-execution-id': "7c24df87-e753-4d28-bb04-d48acd0e6cb3"
+    },
+    action: "Approval",
+    state: "SUCCEEDED",
+    region: "ap-southeast-2",
+    type: {
+      owner: "AWS",
+      provider: "Manual",
+      category: "Approval",
+      version: "1"
+    },
+    version: 2
+  },
+  resources: [
+    "arn:aws:codepipeline:ap-southeast-2:483376129420:lena-test-pipeline"
+  ],
+  additionalAttributes: {}
+}
+
+export const AWS_MANUAL_REQUEST_REJECTED = {
+  account: "483376129420",
+  detailType: "CodePipeline Action Execution State Change",
+  region: "ap-southeast-2",
+  source: "aws.codepipeline",
+  time: "2022-04-13T00:03:25Z",
+  notificationRuleArn: "arn:aws:codestar-notifications:ap-southeast-2:483376129420:notificationrule/06486c59533a1ace24d910539fc74bd351ff13e4",
+  detail: {
+    'pipeline': "lena-test-pipeline",
+    'execution-id': "31c2dcbd-2a1d-42b0-9f37-5bf8cb693b28",
+    stage: "ManualApproval",
+    'execution-result': {
+      'external-execution-summary': "test rejection message",
+      'external-execution-id': "08ad9fe7-6774-4aa8-ba98-1e9707045004",
+      'error-code': "JobFailed"
+    },
+    action: "Approval",
+    state: "FAILED",
+    region: "ap-southeast-2",
+    type: {
+      owner: "AWS",
+      provider: "Manual",
+      category: "Approval",
+      version: "1"
+    },
+    version: 2
+  },
+  resources: [
+    "arn:aws:codepipeline:ap-southeast-2:483376129420:lena-test-pipeline"
+  ],
+  additionalAttributes: {}
+}

--- a/src/bot/CodePipelineBot.ts
+++ b/src/bot/CodePipelineBot.ts
@@ -5,6 +5,7 @@ import {
   PipelineCodeBuildFailure,
   PipelineCodeDeployFailure,
   RawMessage,
+  ManualApprovalNotification,
 } from "../types/common";
 import {
   CodePipelineEvent,
@@ -63,7 +64,7 @@ export class CodePipelineBot extends Bot {
 
   handleMessage = async (
     rawMessage: RawMessage
-  ): Promise<PipelineNotification | null> => {
+  ): Promise<PipelineNotification | ManualApprovalNotification | null> => {
     const codePipelineEvent = rawMessage.body as CodePipelineEvent;
     const eventType = CodePipelineBot.detectEventType(codePipelineEvent);
 
@@ -142,8 +143,18 @@ export class CodePipelineBot extends Bot {
     ) {
       return this.createFailureNotification(this.pipeLog);
     }
+    if (event.detail.type.provider === "Manual") {
+      return this.createManualApprovalNotification(this.pipeLog);
+    }
     return null;
   };
+
+  createManualApprovalNotification = async (
+    pipelog: PipeLog
+  ): Promise<ManualApprovalNotification> => ({
+    type: "ManualApprovalNotification",
+    name: pipelog.name
+  });
 
   createSuccessNotification = async (
     pipelog: PipeLog

--- a/src/bot/CodePipelineBot.ts
+++ b/src/bot/CodePipelineBot.ts
@@ -143,7 +143,9 @@ export class CodePipelineBot extends Bot {
     ) {
       return this.createFailureNotification(this.pipeLog);
     }
-    if (event.detail.type.provider === "Manual") {
+    if (
+      event.detail.type.provider === "Manual" &&
+      event.detail.state === "STARTED") {
       return this.createManualApprovalNotification(this.pipeLog);
     }
     return null;
@@ -153,7 +155,8 @@ export class CodePipelineBot extends Bot {
     pipelog: PipeLog
   ): Promise<ManualApprovalNotification> => ({
     type: "ManualApprovalNotification",
-    name: pipelog.name
+    name: pipelog.name,
+    approvalAttributes: pipelog.approvalAttributes
   });
 
   createSuccessNotification = async (

--- a/src/chat/DiscordChat.ts
+++ b/src/chat/DiscordChat.ts
@@ -18,6 +18,7 @@ export class DiscordChat extends Chat {
   /** Formats and then sends a notification to Discord. */
   sendNotification = async (notification: Notification) => {
     const GREEN = 3066993;
+    const YELLOW = 16705372;
     const DARK_RED = 10038562;
 
     let color;
@@ -65,7 +66,7 @@ export class DiscordChat extends Chat {
       
       case "ManualApprovalNotification": {
         const manualApprovalNotification = notification as ManualApprovalNotification;
-          color = GREEN;
+          color = YELLOW;
           discordMessage = this.discord.createManualApprovalMessage(
             manualApprovalNotification.name,
             manualApprovalNotification.approvalAttributes

--- a/src/chat/DiscordChat.ts
+++ b/src/chat/DiscordChat.ts
@@ -67,7 +67,8 @@ export class DiscordChat extends Chat {
         const manualApprovalNotification = notification as ManualApprovalNotification;
           color = GREEN;
           discordMessage = this.discord.createManualApprovalMessage(
-            manualApprovalNotification.name
+            manualApprovalNotification.name,
+            manualApprovalNotification.approvalAttributes
         );
         break;
       }

--- a/src/chat/DiscordChat.ts
+++ b/src/chat/DiscordChat.ts
@@ -2,6 +2,7 @@ import {
   Notification,
   AlarmNotification,
   PipelineNotification,
+  ManualApprovalNotification,
   SimpleNotification,
 } from "../types/common";
 import { Discord, DiscordMessageType } from "../lib/Discord";
@@ -59,6 +60,15 @@ export class DiscordChat extends Chat {
           );
         }
 
+        break;
+      }
+      
+      case "ManualApprovalNotification": {
+        const manualApprovalNotification = notification as ManualApprovalNotification;
+          color = GREEN;
+          discordMessage = this.discord.createManualApprovalMessage(
+            manualApprovalNotification.name
+        );
         break;
       }
       default:

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,26 +10,23 @@ const GIT_PASSWORD = process.env.GIT_PASSWORD || "";
 const CHAT_SERVICE = process.env.CHAT_SERVICE || "discord";
 /* Debug settings. */
 const DYNAMO_ENDPOINT = process.env.DYNAMO_ENDPOINT;
-const TRACE_EVENTS = process.env.TRACE_EVENTS || false;
+const TRACE_EVENTS = process.env.TRACE_EVENTS || true;
 
 const DYNAMO_DB = new DynamoDBClient({
-  endpoint: DYNAMO_ENDPOINT,
+	endpoint: DYNAMO_ENDPOINT
 });
 
 const CODE_PROVIDER =
-  GIT_PROVIDER.toLowerCase() === "bitbucket"
-    ? new BitBucket(GIT_USERNAME, GIT_PASSWORD)
-    : new GitHub(GIT_USERNAME, GIT_PASSWORD);
+	GIT_PROVIDER.toLowerCase() === "bitbucket"
+		? new BitBucket(GIT_USERNAME, GIT_PASSWORD)
+		: new GitHub(GIT_USERNAME, GIT_PASSWORD);
 
 const meerkat = new Meerkat(DYNAMO_DB, CODE_PROVIDER, CHAT_SERVICE);
 
-export const handler: SNSHandler = async (
-  event: SNSEvent,
-  context?: Context
-) => {
-  console.log("v1.5.1");
-  if (TRACE_EVENTS) {
-    console.log(event.Records[0].Sns.Message);
-  }
-  await meerkat.main(event);
+export const handler: SNSHandler = async (event: SNSEvent, context?: Context) => {
+	console.log("v1.5.2");
+	if (TRACE_EVENTS) {
+		console.log(event.Records[0].Sns.Message);
+	}
+	await meerkat.main(event);
 };

--- a/src/lib/Discord.ts
+++ b/src/lib/Discord.ts
@@ -129,6 +129,19 @@ export class Discord {
     return message;
   }
 
+  public createManualApprovalMessage(
+    pipeLineName: string
+  ): DiscordMessageType {
+
+    const message: DiscordMessageType = {
+      title: `:smirk: ${pipeLineName} requires manual approval.`,
+      description: "",
+      fields: [],
+      footer: "",
+    };
+    return message;
+  }
+
   public simpleMessage(subject: string, message: string): DiscordMessageType {
     return {
       title: `:skull_crossbones: ${subject}`,

--- a/src/lib/Discord.ts
+++ b/src/lib/Discord.ts
@@ -4,6 +4,7 @@ import {
   AlarmNotification,
   PipelineCodeBuildFailure,
   PipelineCodeDeployFailure,
+  ManualApprovalAttributes,
 } from "../types/common";
 
 export interface DiscordMessageType {
@@ -130,15 +131,34 @@ export class Discord {
   }
 
   public createManualApprovalMessage(
-    pipeLineName: string
+    pipeLineName: string,
+    manualAttributes: ManualApprovalAttributes
   ): DiscordMessageType {
 
     const message: DiscordMessageType = {
-      title: `:smirk: ${pipeLineName} requires manual approval.`,
+      title: `:sneeze: ${pipeLineName} requires manual approval.`,
       description: "",
       fields: [],
       footer: "",
     };
+
+    if (manualAttributes.link !== "") {
+      message.fields.push(
+        {
+          name: `Review Link:`,
+          value: `${manualAttributes.link}`
+        }
+      );
+    }
+    if (manualAttributes.comment !== "") {
+      message.fields.push(
+        {
+          name: `Comments:`,
+          value: `${manualAttributes.comment}`
+        }
+      );
+    }
+
     return message;
   }
 

--- a/src/types/AwsCodePipeline.d.ts
+++ b/src/types/AwsCodePipeline.d.ts
@@ -109,5 +109,7 @@ export type CodePipelineActionEvent = CodePipelineEvent & {
   additionalAttributes: {
     sourceActions?: any[];
     additionalInformation?: string;
+    externalEntityLink?: string;
+    customData?: string;
   };
 };

--- a/src/types/common.d.ts
+++ b/src/types/common.d.ts
@@ -109,6 +109,15 @@ export type PipelineNotification = Notification & {
   failureDetail?: PipelineCodeBuildFailure | PipelineCodeDeployFailure;
 };
 
+/**
+ * A notification that contains information related to a manual approval being required for pipeline execution to resume.
+ */
+ export type ManualApprovalNotification = Notification & {
+  type: "ManualApprovalNotification";
+  /**  The name of the pipeline that triggered the notification. */
+  name: string;
+ }
+
 /** Extra information for troubleshooting pipeline failures caused by AWS Code Build. */
 export type PipelineCodeBuildFailure = {
   type: "CodeBuild";

--- a/src/types/common.d.ts
+++ b/src/types/common.d.ts
@@ -12,6 +12,15 @@ export interface Commit {
   link: string;
 }
 
+  /** Optional information related to a manual approval request.
+   */
+export interface ManualApprovalAttributes {
+   /** A URL added for additional review before approval. */
+  link?: string;
+  /** Any comments related to the approval request. */
+  comment?: string;
+}
+
 /**
  * A log entry is an abstracted form of an AWS Code pipeline event. AWS Code Pipeline events contain a lot of meta data.
  * Furthermore, a each different event type has a slightly different format.
@@ -116,6 +125,8 @@ export type PipelineNotification = Notification & {
   type: "ManualApprovalNotification";
   /**  The name of the pipeline that triggered the notification. */
   name: string;
+  /**  Optional information to be reviewed by approvers. */
+  approvalAttributes: ManualApprovalAttributes;
  }
 
 /** Extra information for troubleshooting pipeline failures caused by AWS Code Build. */


### PR DESCRIPTION
- Handles incoming manual approval required messages
- Sends out a notification which contains the pipeline requiring approval, and any additional links and comments for review.